### PR TITLE
updates: avoid deprecations

### DIFF
--- a/ocha_monitoring.module
+++ b/ocha_monitoring.module
@@ -7,7 +7,7 @@
 
 use Drupal\monitoring\Entity\SensorConfig;
 use Symfony\Component\Yaml\Yaml;
-use DrupalFinder\DrupalFinder;
+use DrupalFinder\DrupalFinderComposerRuntime;
 use GuzzleHttp\TransferStats;
 
 /**
@@ -104,8 +104,8 @@ function ocha_monitoring_enforce_monitors() {
  * Get installed version from composer.
  */
 function ocha_monitoring_get_version_info_from_composer($prefix, $project) {
-  $drupalFinder = new DrupalFinder();
-  if (!$drupalFinder->locateRoot(DRUPAL_ROOT)) {
+  $drupalFinder = new DrupalFinderComposerRuntime();
+  if (!$drupalFinder->getDrupalRoot()) {
     return [];
   }
 


### PR DESCRIPTION
Refs: OPS-11341

Upgrade_status report copied from the ticket:

|STATUS    |     LINE      |      MESSAGE    | 
|-------|--------|-------|
|Check manually |107 | Instantiation of deprecated class DrupalFinder\DrupalFinder.
| | |                    Deprecated in drupal-finder:1.3.0 and is removed from       
| | |                    drupal-finder:2.0.0. Use                                    
| | |                    DrupalFinder\DrupalFinderComposerRuntime instead.           
|Check manually | 108 | Call to deprecated method locateRoot() of class             
| | |                    DrupalFinder\DrupalFinder: Will be removed in v2. Future    
| | |                    usage should instantiate a new DrupalFinder object by       
| | |                    passing the starting path to its constructor.               
