### PR TITLE
fix: require DrupalFinder to avoid errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "GPL-2.0-or-later",
     "type": "drupal-module",
     "require": {
-        "drupal/monitoring": "^1"
+        "drupal/monitoring": "^1",
+        "webflo/drupal-finder": "^1.3"
     }
 }


### PR DESCRIPTION
Refs: OPS-11467
